### PR TITLE
~160x faster write speed, ~2x effective storage size, may break compa…

### DIFF
--- a/Firmware/Qwiic_OpenLog/commands.ino
+++ b/Firmware/Qwiic_OpenLog/commands.ino
@@ -216,8 +216,18 @@ void openFile(char *myData) {
   }
 }
 
+//we don't actually want to sync() every time we write to the buffer
+//writing a full buffer to the card and writing 1 or 2 bytes seems
+//to take about the same amount of time. Once the buffer is full
+//it will automatically sync anyways.
 void writeFile(char *myData) {
-  workingFile.write(myData, sizeof(myData));
+  workingFile.write(myData, strlen(myData));
+  valueMap.status |= (1 << STATUS_LAST_COMMAND_SUCCESS); //Command success
+}
+
+//if you definitely want your buffer synced right now then you can 
+//manually call it
+void syncFile(char *myData) {
   workingFile.sync();
   valueMap.status |= (1 << STATUS_LAST_COMMAND_SUCCESS); //Command success
 }
@@ -549,4 +559,3 @@ void loadArrayWithFileName(FatFile * theDir, char * cmdStr)
   tempFile.close();
   return;
 }
-


### PR DESCRIPTION
…tibility with older code

Changed writeFile so it:
-doesn't sync to SD card every byte written
-doesn't write an extra null character after every byte specified by the user to be written. sizeof(*myData) does *not* return the length of the string. It returns the size of the type pointer to char, which on the m328p is two bytes. Thus, every time writeFile is called it writes the byte the user supplied and the zeroed out byte right ahead of it. When you take out the sd card and view it on your computer you may not see this because a lot of text editors silently ignore most special ASCII characters. View in VIM or Sublime to see for yourself.

Added syncFile function and neccesary additions to memoryMap, registerMap, valueMap, functionMap:
-If user doesn't want for the buffer to get full and the write to sd card to be automatically called you can manually call it to be sure your data will be written before whatever device you have is shutoff, loses battery, implodes, etc.

I couldn't find where lastSyncTime was updated so I updated it with millis() whenever the receiveEvent or requestEvent callbacks are initiated. I'm not really sure of this one because I have done zero testing of the low power mode.

You may want to change some things around like keeping the old writeFile function the same for backwards compatibility and adding a new function and i2c register for this style of fast writing.